### PR TITLE
fix: renderer looking for incorrect elements

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,14 +1,20 @@
-import { DynamicTOCSettings, EXTERNAL_MARKDOWN_PREVIEW_STYLE } from "./types";
+import {
+  DynamicTOCSettings,
+  ExternalMarkdownKey,
+  EXTERNAL_MARKDOWN_PREVIEW_STYLE,
+} from "./types";
 
 export const DEFAULT_SETTINGS: DynamicTOCSettings = {
   style: "bullet",
   min_depth: 2,
   max_depth: 6,
-  externalStyle: "",
+  externalStyle: "None",
   supportAllMatchers: false,
 };
 
 export const TABLE_CLASS_NAME = "dynamic-toc";
 export const TABLE_CLASS_SELECTOR = `.${TABLE_CLASS_NAME}`;
 
-export const ALL_MATCHERS = Object.keys(EXTERNAL_MARKDOWN_PREVIEW_STYLE);
+export const ALL_MATCHERS = Object.keys(
+  EXTERNAL_MARKDOWN_PREVIEW_STYLE
+) as ExternalMarkdownKey[];

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,11 @@ import { parseConfig } from "./utils/config";
 import { ALL_MATCHERS, DEFAULT_SETTINGS } from "./constants";
 import { ContentsRenderer } from "./renderers/contents-renderer";
 import { DynamicTOCSettingsTab } from "./settings-tab";
-import { DynamicTOCSettings, EXTERNAL_MARKDOWN_PREVIEW_STYLE } from "./types";
+import {
+  DynamicTOCSettings,
+  ExternalMarkdownKey,
+  EXTERNAL_MARKDOWN_PREVIEW_STYLE,
+} from "./types";
 import { DynamicInjectionRenderer } from "./renderers/dynamic-injection-renderer";
 
 export default class DynamicTOCPlugin extends Plugin {
@@ -25,13 +29,16 @@ export default class DynamicTOCPlugin extends Plugin {
 
     this.registerMarkdownPostProcessor(
       (el: HTMLElement, ctx: MarkdownPostProcessorContext) => {
-        const matchers: string[] =
+        const matchers =
           this.settings.supportAllMatchers === true
             ? ALL_MATCHERS
             : [EXTERNAL_MARKDOWN_PREVIEW_STYLE[this.settings.externalStyle]];
-        for (let matcher of matchers) {
-          if (!matcher) continue;
-          const match = DynamicInjectionRenderer.findMatch(el, matcher);
+        for (let matcher of matchers as ExternalMarkdownKey[]) {
+          if (!matcher || matcher === "None") continue;
+          const match = DynamicInjectionRenderer.findMatch(
+            el,
+            EXTERNAL_MARKDOWN_PREVIEW_STYLE[matcher as ExternalMarkdownKey]
+          );
           if (!match?.parentNode) continue;
           ctx.addChild(
             new DynamicInjectionRenderer(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "target": "es6",
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "suppressImplicitAnyIndexErrors": true,
     "allowJs": true,
     "noImplicitAny": true,
     "moduleResolution": "node",


### PR DESCRIPTION
Possibly fixes #14. The renderer was using the matcher KEY not the matcher value for finding things. So it would match over aggressively. Potentially causing some errors to occur.